### PR TITLE
feat: add sign-in sign-up

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -23,6 +23,14 @@ html lang="en"
           = "Task Manager"
         .mdl-layout-spacer
         nav.mdl-navigation
+          = link_to "Board", board_path, class: 'mdl-navigation__link'
+          - if current_user
+            - if current_user.is_a? Admin
+              = link_to "Admin page", admin_users_url, class: 'mdl-navigation__link'
+            = link_to "Log out", session_path, method: "delete", confirm: "confirm?", class: 'mdl-navigation__link'
+          - else
+            = link_to "Sign in", new_session_path, class: 'mdl-navigation__link'
+            = link_to "Sign up", new_developers_path, class: 'mdl-navigation__link'
     main#main.mdl-layout__content
       .page-content
         = yield


### PR DESCRIPTION
Я специально делаю мерж в ветку до сессии и авторизации, чтобы тебе было виднее мои файлы на этом этапе и проблема виднее

у меня работает только форма Sign Up.
Sign in / Log out (после регистрации) - выдают такую ошибку, я не понимаю, в чем проблема.

<img width="1512" alt="Screenshot 2022-11-16 at 18 05 37" src="https://user-images.githubusercontent.com/71670937/202246940-00353cba-c8a1-4765-ad65-18fb5bcff239.png">

p.s. исходя из вывода rails routes исправил
<img width="1364" alt="Screenshot 2022-11-16 at 18 11 05" src="https://user-images.githubusercontent.com/71670937/202247428-59fdf093-0a09-48a5-a34d-019286003cf3.png">

`link_to "Sign up", new_developer_path` (в уроке) на 

`link_to "Sign up", new_developers_path`

т.к тоже выдавал путь ошибку
